### PR TITLE
Fix PHP 8 round method fatal error on strings

### DIFF
--- a/src/ValidationMessages.php
+++ b/src/ValidationMessages.php
@@ -55,7 +55,7 @@ class ValidationMessages
 	 	self::$app = include __DIR__ . '/Config.php';
 
 	 	if ( $validator ) {
-	 		if ( round((int)App::version(), 1) > self::$app['version'] ) {
+	 		if ( round(floatval(App::version()), 1) > self::$app['version'] ) {
 	 			self::$messages = $validator->customMessages;
 	 		} else {
 	 			self::$messages = $validator->getCustomMessages();


### PR DESCRIPTION
Use floatval method instead of int if there is a reason to round Laravel versions